### PR TITLE
Update @angular/cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "zone.js": "^0.8.4"
   },
   "devDependencies": {
-    "@angular/cli": "1.5.4",
+    "@angular/cli": "1.6.7",
     "@angular/compiler-cli": "^5.0.0",
     "@angular/language-service": "^5.0.0",
     "@types/jasmine": "~2.5.53",


### PR DESCRIPTION
Previously, an exported project threw an error when trying to build: cannot find module `@angular-devkit/core`

This commit updates the @angular/cli package to a version which resolves this error as mentioned in: https://github.com/angular/angular-cli/issues/9307

This should resolve https://github.com/stackblitz/core/issues/252

Note I've updated to 1.6.7, not the latest. Maybe it's an idea if I upgrade all angular dependencies to the latest (stable) angular release?